### PR TITLE
 #168205908 add change user to a mentor endpoint

### DIFF
--- a/FREE-MENTORS_BACKEND/CONTROLLERS/userAcc_Controler.js
+++ b/FREE-MENTORS_BACKEND/CONTROLLERS/userAcc_Controler.js
@@ -127,6 +127,48 @@ class userAccountControler{
             }
         }
     }
+
+    //Change a user to a mentor(Done By admin)
+    ChangeUserToMentor(req, res){
+        const user_id= parseInt(req.params.userId);
+        const all_users= accounts.AllAccounts;
+        const user_found= all_users.find(users=>users.userId===user_id);
+        if(user_found){
+            const new_role= true;
+            const admin_role_check= req.user_token.is_admin;
+            if(admin_role_check===true){
+                user_found.is_a_mentor= new_role;
+                const updated_user_acc= user_found;
+                return res.status(200).json({
+                    status: 200,
+                    message: "User account changed to mentor",
+                    data: {
+                        userId: updated_user_acc.userId,
+                        firstName: updated_user_acc.firstName,
+                        lastName: updated_user_acc.lastName,
+                        email: updated_user_acc.email,
+                        address: updated_user_acc.address,
+                        bio: updated_user_acc.bio,
+                        occupation: updated_user_acc.occupation,
+                        expertise: updated_user_acc.expertise,
+                        is_admin: updated_user_acc.is_admin,
+                        is_a_mentor: updated_user_acc.is_a_mentor
+                    }
+                });
+            }else{
+                return res.status(400).json({
+                    status: 400,
+                    error: "Only Administrator can change a user to a mentor"
+                });
+            }
+        }else{
+            return res.status(404).json({
+                status: 404,
+                error: "A mentee with such userId not found"
+            });
+        }
+    }
+
 }
 
 const account_controler= new userAccountControler();

--- a/FREE-MENTORS_BACKEND/ROUTES/Routes.js
+++ b/FREE-MENTORS_BACKEND/ROUTES/Routes.js
@@ -1,9 +1,11 @@
 import express from 'express';
 import account_controler from '../CONTROLLERS/userAcc_Controler';
+import {verifyToken} from '../JWT/jwt_conf';
 
 const router= express.Router();
 
 //User accounts routes
 router.post('/api/v1/auth/signup',account_controler.createUseraccount); //Endpoint to create user account
 router.post('/api/v1/auth/signin',account_controler.userLogin); //Endpoint to login a user
+router.patch('/api/v1/user/:userId',verifyToken, account_controler.ChangeUserToMentor); //Endpoint to change user to mentor
 export default router;


### PR DESCRIPTION
#### What does this PR do?
creates change user to a mentor endpoint
#### Description of Task to be completed?
change user to a mentor endpoint takes (admin token through the header and the mentee Id through the request parameter) as request and returns (message, firstName, lastName, email, address, bio, occupation, expertise, is_admin and is_a_mentor(true)) as response. Also response status code may be 200: for a user successfully changed to a mentor, 404: for a mentee Id not found and 400: for a user trying to change another user to a mentor while the previous one is not an administrator.
#### How should this be manually tested?
- Clone this repository to the computer and "run npm start" into your VS CODE EDITOR console. Open POSTMAN, choose PATCH method and then type "localhost:3000/api/v1/auth/user/:userId". replace (:userId) by a number of your choice. In the Headers section of POSTMAN type in               "x-auth-token" in the value area paste the token provided after logging in an admin.And then hit SEND button
#### What are the relevant pivotal tracker stories?
change_user_to_a_mentor-168205908
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/53488656/63089653-d8647400-bf58-11e9-836b-7d5392fe00e9.png)

