### PR TITLE
#168206006 add view a specific mentor endpoint

### DIFF
--- a/FREE-MENTORS_BACKEND/CONTROLLERS/userAcc_Controler.js
+++ b/FREE-MENTORS_BACKEND/CONTROLLERS/userAcc_Controler.js
@@ -179,6 +179,43 @@ class userAccountControler{
             });
     }
 
+    //View a specific mentor by Id
+    viewMentorById(req, res){
+        const single_user_id= parseInt(req.params.userId);
+        const all_users_accs= accounts.AllAccounts;
+        const user_acc= all_users_accs.find(acc=>acc.userId===single_user_id);
+        if(!(user_acc)){
+            return res.status(404).json({
+                status: 404,
+                error: "A user with such Id not found"
+            });
+        }else{
+            const mentor_check_val= user_acc.is_a_mentor;
+            if(mentor_check_val===true){
+                return res.status(200).json({
+                    status: 200,
+                    data: {
+                        mentorId: user_acc.userId,
+                        firstName: user_acc.firstName,
+                        lastName: user_acc.lastName,
+                        email: user_acc.email,
+                        address: user_acc.address,
+                        bio: user_acc.bio,
+                        occupation: user_acc.occupation,
+                        expertise: user_acc.expertise,
+                        is_admin: user_acc.is_admin,
+                        is_a_mentor: user_acc.is_a_mentor
+                    }
+                });
+            }else{
+                return res.status(404).json({
+                    status: 404,
+                    error: "A mentor for this Id not found"
+                });
+            }
+        }
+    }
+
 }
 
 const account_controler= new userAccountControler();

--- a/FREE-MENTORS_BACKEND/ROUTES/Routes.js
+++ b/FREE-MENTORS_BACKEND/ROUTES/Routes.js
@@ -9,4 +9,5 @@ router.post('/api/v1/auth/signup',account_controler.createUseraccount); //Endpoi
 router.post('/api/v1/auth/signin',account_controler.userLogin); //Endpoint to login a user
 router.patch('/api/v1/user/:userId',verifyToken, account_controler.ChangeUserToMentor); //Endpoint to change user to mentor
 router.get('/api/v1/mentors',verifyToken, account_controler.viewAllMentors); //Endpoint to view all registered mentors
+router.get('/api/v1/mentors/:userId',verifyToken, account_controler.viewMentorById); //Endpoint to view a specific mentor by Id
 export default router;


### PR DESCRIPTION
#### What does this PR do?
view a specific mentor endpoint
#### Description of Task to be completed?
view a specific mentor endpoint takes (user token and mentorId) as request and returns (firstName, lastName, email, address, bio, occupation, expertise, is_admin and is_a_mentor) as response. Also response status code may be 200: for a successful response, 404: for a non available mentor 
#### How should this be manually tested?
- Clone this repository to the computer and "run npm start" into your VS CODE EDITOR console. 
- Login and get the token
- use GET http verb, type "x-auth-token" in Header section of POSTMAN and paste the copied token into the "x-auth-token" value section
- Type "localhost:3000/api/v1/mentors/:userId" and replace (:userId) by any number of your choice  and hit SEND button
#### What are the relevant pivotal tracker stories?
view_a_specific_mentor-168206006
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/53488656/63126241-bcd88800-bfaf-11e9-8a83-7dc0d0a619a9.png)

