### PR TITLE
#168206022 add create mentorship session request endpoint

### DIFF
--- a/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
+++ b/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
@@ -1,0 +1,53 @@
+import session_inst from '../MODELS/session';
+import accounts from '../MODELS/User_Accounts';
+import session_schema from '../JOI_VALIDATION/session_validation';
+import Joi from '@hapi/joi';
+
+class sessionControler{
+    createSession(req, res){
+        const mentorId= parseInt(req.body.mentorId);
+        const questions= req.body.questions;
+        const create_session_validation = Joi.validate(req.body, session_schema);
+        if(create_session_validation.error){
+            const create_session_errors=[];
+            for(let index=0; index<create_session_validation.error.details.length; index++){
+                create_session_errors.push(create_session_validation.error.details[index].message.split('"').join(" "));
+            }
+            return res.status(400).send({
+                status: 400,
+                error: create_session_errors
+            });
+        }else{
+            const allAccs= accounts.AllAccounts;
+            const USER_ACC= allAccs.find(accs=>accs.userId===parseInt(mentorId));
+            if(!(USER_ACC)){
+                return res.status(404).json({
+                    status: 404,
+                    error: "A user with such Id not found"
+                });
+            }else{
+                const mentor_checking= USER_ACC.is_a_mentor;
+                if(mentor_checking===true){
+                    const menteeId= req.user_token.userId;
+                    const menteeEmail= req.user_token.email;
+                    const status="pending";
+                    const input_data= {mentorId, menteeId, questions, menteeEmail, status};
+                    
+                    const createdSession= session_inst.createSession(input_data);
+                    return res.status(200).json({
+                        status: 200,
+                        data: createdSession
+                    });
+                }else{
+                    return res.status(404).json({
+                        status: 404,
+                        error: "A mentor with such Id not found"
+                    });
+                }
+            }
+        }
+    }
+}
+
+const session_contrl= new sessionControler();
+export default session_contrl;

--- a/FREE-MENTORS_BACKEND/JOI_VALIDATION/session_validation.js
+++ b/FREE-MENTORS_BACKEND/JOI_VALIDATION/session_validation.js
@@ -1,0 +1,8 @@
+import Joi from '@hapi/joi';
+
+const session_schema={
+    mentorId: Joi.number().integer().required(),
+    questions: Joi.string().required()
+};
+
+export default session_schema;

--- a/FREE-MENTORS_BACKEND/MODELS/session.js
+++ b/FREE-MENTORS_BACKEND/MODELS/session.js
@@ -1,0 +1,20 @@
+class Session{
+    constructor(){
+        this.allSessions=[];
+    }
+    createSession(req){
+        const single_session={
+            sessionId: this.allSessions.length+1,
+            mentorId: req.mentorId,
+            menteeId: req.menteeId,
+            questions: req.questions,
+            menteeEmail: req.menteeEmail,
+            status: req.status
+        }
+        this.allSessions.push(single_session);
+        return single_session;
+    }
+}
+
+const session_inst= new Session();
+export default session_inst;

--- a/FREE-MENTORS_BACKEND/ROUTES/Routes.js
+++ b/FREE-MENTORS_BACKEND/ROUTES/Routes.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import account_controler from '../CONTROLLERS/userAcc_Controler';
+import session_contrl from '../CONTROLLERS/session_Controler';
 import {verifyToken} from '../JWT/jwt_conf';
 
 const router= express.Router();
@@ -10,4 +11,8 @@ router.post('/api/v1/auth/signin',account_controler.userLogin); //Endpoint to lo
 router.patch('/api/v1/user/:userId',verifyToken, account_controler.ChangeUserToMentor); //Endpoint to change user to mentor
 router.get('/api/v1/mentors',verifyToken, account_controler.viewAllMentors); //Endpoint to view all registered mentors
 router.get('/api/v1/mentors/:userId',verifyToken, account_controler.viewMentorById); //Endpoint to view a specific mentor by Id
+
+//Mentorship session routes
+router.post('/api/v1/session',verifyToken, session_contrl.createSession); //Create mentorship session
+
 export default router;


### PR DESCRIPTION
#### What does this PR do?
create mentorship session endpoint
#### Description of Task to be completed?
create mentorship session endpoint takes (user token, mentorId and questions) as request and returns (sessionId, mentorId, menteeId, questions, menteeEmail and status) as response. Also response status code may be 200: for a successful response, 404: for a non available mentor 
#### How should this be manually tested?
- Clone this repository to the computer and "run npm start" into your VS CODE EDITOR console. 
- Login and get the token
- use GET http verb, type "x-auth-token" in Header section of POSTMAN and paste the copied token into the "x-auth-token" value section
- In the Body section fill in mentorId and questions along with their respective values
- Type "localhost:3000/api/v1/sessions" and hit SEND button
#### What are the relevant pivotal tracker stories?
create_mentorship_session_request-168206022
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/53488656/63132402-45135900-bfc1-11e9-8140-c556ac51d6f7.png)


