### PR TITLE
#168206037 add mentor accept mentorship session endpoint

### DIFF
--- a/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
+++ b/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
@@ -47,6 +47,36 @@ class sessionControler{
             }
         }
     }
+
+    //Mentor accept mentorship session
+    acceptSessionRequest(req, res){
+        const sessId= parseInt(req.params.sessionId);
+        const all_sess= session_inst.allSessions;
+        const session_lookup= all_sess.find(single_sess=>single_sess.sessionId===sessId);
+        if(session_lookup){
+            const mentorId= req.user_token.userId;
+            const check_session_mentor= session_lookup.mentorId;
+            if(check_session_mentor===mentorId){
+                const new_status= "accepted";
+                session_lookup.status= new_status;
+                const updatedSession= session_lookup;
+                return res.status(200).json({
+                    status: 200,
+                    data: updatedSession
+                });
+            }else{
+                return res.status(404).json({
+                    status: 404,
+                    error: "You are not a mentor for this session"
+                })
+            }
+        }else{
+            return res.status(404).json({
+                status: 404,
+                error: "No session with such Id found"
+            })
+        }
+    }
 }
 
 const session_contrl= new sessionControler();

--- a/FREE-MENTORS_BACKEND/ROUTES/Routes.js
+++ b/FREE-MENTORS_BACKEND/ROUTES/Routes.js
@@ -14,5 +14,6 @@ router.get('/api/v1/mentors/:userId',verifyToken, account_controler.viewMentorBy
 
 //Mentorship session routes
 router.post('/api/v1/session',verifyToken, session_contrl.createSession); //Create mentorship session
+router.patch('/api/v1/sessions/:sessionId/accept',verifyToken, session_contrl.acceptSessionRequest); //Accept session req
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
mentor accept mentorship session endpoint
#### Description of Task to be completed?
mentor accept mentorship session endpoint takes (user token and sessionId) as request and returns (sessionId, mentorId, menteeId, question, menteeEmail, status) as response. Also response status code may be: 
- 200: for a session successfully updated 
- 400: invalid input
- 404: for a mentor trying to update a session that doesn't exist
- 404: for  user trying to update a session while he/she is not a mentor and 
- 403: when a token has not been provided

#### How should this be manually tested?
- Clone this repository to the computer and "run npm start" into your VS CODE EDITOR console. 
- Login and get the token
- use PATCH http verb, type "x-auth-token" in Header section of POSTMAN and paste the copied token into the "x-auth-token" value section
- Type "localhost:3000/api/v1/sessions/:sessionId/accept" and replace (:sessionId) by any number of your choice  and hit SEND button
#### What are the relevant pivotal tracker stories?
mentor_accept_mentorship_session-168206037
#### Screenshots (if appropriate)
![mentor_accept_session_screenshot](https://user-images.githubusercontent.com/53488656/63165493-e9ca8080-c02b-11e9-95cf-efeb79b43d16.PNG)

