### PR TITLE
#168206055 add mentor reject mentorship session

### DIFF
--- a/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
+++ b/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
@@ -77,6 +77,36 @@ class sessionControler{
             })
         }
     }
+
+    //Mentor reject mentorship session
+    rejectSessionRequest(req, res){
+        const sessioId= parseInt(req.params.sessionId);
+        const all_sessio= session_inst.allSessions;
+        const session_lookups= all_sessio.find(single_sessio=>single_sessio.sessionId===sessioId);
+        if(session_lookups){
+            const mentorId= req.user_token.userId;
+            const check_session_mentors= session_lookups.mentorId;
+            if(check_session_mentors===mentorId){
+                const new_session_status= "rejected";
+                session_lookups.status= new_session_status;
+                const updatedSessions= session_lookups;
+                return res.status(200).json({
+                    status: 200,
+                    data: updatedSessions
+                });
+            }else{
+                return res.status(404).json({
+                    status: 404,
+                    error: "You are not a mentor for this session"
+                })
+            }
+        }else{
+            return res.status(404).json({
+                status: 404,
+                error: "No session with such Id found"
+            })
+        }
+    }
 }
 
 const session_contrl= new sessionControler();

--- a/FREE-MENTORS_BACKEND/ROUTES/Routes.js
+++ b/FREE-MENTORS_BACKEND/ROUTES/Routes.js
@@ -15,5 +15,6 @@ router.get('/api/v1/mentors/:userId',verifyToken, account_controler.viewMentorBy
 //Mentorship session routes
 router.post('/api/v1/session',verifyToken, session_contrl.createSession); //Create mentorship session
 router.patch('/api/v1/sessions/:sessionId/accept',verifyToken, session_contrl.acceptSessionRequest); //Accept session req
+router.patch('/api/v1/sessions/:sessionId/reject',verifyToken, session_contrl.rejectSessionRequest); //Reject session req
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
mentor reject mentorship session endpoint
#### Description of Task to be completed?
mentor reject mentorship session endpoint takes (user token and sessionId) as request and returns (sessionId, mentorId, menteeId, question, menteeEmail, status) as response. Also response status code may be: 
- 200: for a session successfully updated 
- 400: invalid input
- 404: for a mentor trying to update a session that doesn't exist
- 404: for  user trying to update a session while he/she is not a mentor and 
- 403: when a token has not been provided

#### How should this be manually tested?
- Clone this repository to the computer and "run npm start" into your VS CODE EDITOR console. 
- Login and get the token
- use PATCH http verb, type "x-auth-token" in Header section of POSTMAN and paste the copied token into the "x-auth-token" value section
- Type "localhost:3000/api/v1/sessions/:sessionId/reject" and replace (:sessionId) by any number of your choice  and hit SEND button
#### What are the relevant pivotal tracker stories?
mentor_reject_mentorship_session-168206055
#### Screenshots (if appropriate)
![reject_session_screensht](https://user-images.githubusercontent.com/53488656/63166956-1e403b80-c030-11e9-8255-e96dd822810f.PNG)
