### PR TITLE
#168206067 add get all mentorship session requests endpoint 

### DIFF
--- a/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
+++ b/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
@@ -107,6 +107,42 @@ class sessionControler{
             })
         }
     }
+
+    //Get or View all sessions
+    getAllSession(req, res){
+        const is_mentor_checking= req.user_token.is_a_mentor;
+        const allsess= session_inst.allSessions;
+
+        if(is_mentor_checking===false){
+            const mentee_ID= req.user_token.userId;
+            const mentee_sessions= allsess.filter(mentee=>mentee.menteeId===mentee_ID);
+            if(mentee_sessions.length>=1){
+                return res.status(200).json({
+                    status: 200,
+                    data: mentee_sessions
+                });
+            }else{
+                return res.status(404).json({
+                    status: 404,
+                    error: "No mentorship session found"
+                });
+            }
+        }else{
+            const mentor_ID= req.user_token.userId;
+            const mentor_sessions= allsess.filter(mentor=>mentor.mentorId===mentor_ID);
+            if(mentor_sessions.length>=1){
+                return res.status(200).json({
+                    status: 200,
+                    data: mentor_sessions
+                });
+            }else{
+                return res.status(404).json({
+                    status: 404,
+                    error: "No mentorship session found"
+                });
+            }
+        }
+    }
 }
 
 const session_contrl= new sessionControler();

--- a/FREE-MENTORS_BACKEND/ROUTES/Routes.js
+++ b/FREE-MENTORS_BACKEND/ROUTES/Routes.js
@@ -16,5 +16,6 @@ router.get('/api/v1/mentors/:userId',verifyToken, account_controler.viewMentorBy
 router.post('/api/v1/session',verifyToken, session_contrl.createSession); //Create mentorship session
 router.patch('/api/v1/sessions/:sessionId/accept',verifyToken, session_contrl.acceptSessionRequest); //Accept session req
 router.patch('/api/v1/sessions/:sessionId/reject',verifyToken, session_contrl.rejectSessionRequest); //Reject session req
+router.get('/api/v1/sessions',verifyToken, session_contrl.getAllSession); //Get all mentorship sessions
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
get all mentorship sessions endpoint
#### Description of Task to be completed?
get all mentorship sessions endpoint takes (user token) as request and returns (sessionId, mentorId, menteeId, question, menteeEmail, status) as response. Also response status code may be: 
- 200: In case a session(s) is successfully found
- 404: for a user(mentee or mentor) trying to view unavailable session(s)
- 403: when a token has not been provided

#### How should this be manually tested?
- Clone this repository to the computer and "run npm start" into your VS CODE EDITOR console. 
- Login and get the token
- use GET http verb, type "x-auth-token" in Header section of POSTMAN and paste the copied token into the "x-auth-token" value section
- Type "localhost:3000/api/v1/sessions" and hit SEND button
#### What are the relevant pivotal tracker stories?
get_all_mentorship_session_requests-168206067
#### Screenshots (if appropriate)
![view_all_sessions_screenshot](https://user-images.githubusercontent.com/53488656/63170606-ed650400-c039-11e9-85d4-ac7275c57958.PNG)

