### PR TITLE
#168206083 add review mentorship session endpoint

### DIFF
--- a/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
+++ b/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
@@ -1,6 +1,7 @@
 import session_inst from '../MODELS/session';
 import accounts from '../MODELS/User_Accounts';
 import session_schema from '../JOI_VALIDATION/session_validation';
+import session_review_schema from '../JOI_VALIDATION/session_review';
 import Joi from '@hapi/joi';
 
 class sessionControler{
@@ -139,6 +140,57 @@ class sessionControler{
                 return res.status(404).json({
                     status: 404,
                     error: "No mentorship session found"
+                });
+            }
+        }
+    }
+
+    //Review a specific mentorship session
+    reviewSession(req, res){
+        const session_review_validation = Joi.validate(req.body, session_review_schema);
+        if(session_review_validation.error){
+            const session_review_errors=[];
+            for(let index=0; index<session_review_validation.error.details.length; index++){
+                session_review_errors.push(session_review_validation.error.details[index].message.split('"').join(" "));
+            }
+            return res.status(400).send({
+                status: 400,
+                error: session_review_errors[0]
+            });
+        }else{
+            const sessioIDs=parseInt(req.params.sessionId);
+            const menteeIDs=req.user_token.userId;
+            const allSESSIONS= session_inst.allSessions;
+            const single_session_search= allSESSIONS.find(single_sess=>single_sess.sessionId===sessioIDs);
+            if(single_session_search){
+                const found_session_menteeId= single_session_search.menteeId;
+                const found_session_status= single_session_search.status;
+                if(found_session_menteeId===menteeIDs && found_session_status==="accepted"){
+                    const score= parseInt(req.body.score);
+                    const firstname= req.user_token.firstName;
+                    const lastname= req.user_token.lastName;
+                    const menteeFullName= firstname +" " +lastname;
+                    const remark= req.body.remark;
+
+                    //Add properties to a session
+                    single_session_search.score=score;
+                    single_session_search.menteeFullName= menteeFullName;
+                    single_session_search.remark= remark;
+
+                    return res.status(200).json({
+                        status: 200,
+                        data: single_session_search
+                    });
+                }else{
+                    return res.status(404).json({
+                        status: 404,
+                        error: "You are not allowed to review this session"
+                    });
+                }
+            }else{
+                return res.status(404).json({
+                    status: 404,
+                    error: "mentorship session not found"
                 });
             }
         }

--- a/FREE-MENTORS_BACKEND/JOI_VALIDATION/session_review.js
+++ b/FREE-MENTORS_BACKEND/JOI_VALIDATION/session_review.js
@@ -1,0 +1,8 @@
+import Joi from '@hapi/joi';
+
+const session_review_schema={
+    score: Joi.number().integer().min(1).max(5).required(),
+    remark: Joi.string().required()
+};
+
+export default session_review_schema;

--- a/FREE-MENTORS_BACKEND/ROUTES/Routes.js
+++ b/FREE-MENTORS_BACKEND/ROUTES/Routes.js
@@ -17,5 +17,6 @@ router.post('/api/v1/session',verifyToken, session_contrl.createSession); //Crea
 router.patch('/api/v1/sessions/:sessionId/accept',verifyToken, session_contrl.acceptSessionRequest); //Accept session req
 router.patch('/api/v1/sessions/:sessionId/reject',verifyToken, session_contrl.rejectSessionRequest); //Reject session req
 router.get('/api/v1/sessions',verifyToken, session_contrl.getAllSession); //Get all mentorship sessions
+router.post('/api/v1/session/:sessionId/review',verifyToken,session_contrl.reviewSession); //Review a mentorship session
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
review mentorship session endpoint
#### Description of Task to be completed?
review mentorship session endpoint takes (user token, sessionId, score and remark) as request and returns (sessionId, mentorId, menteeId, question, menteeEmail, status, score, menteeFullname and remark) as response. Also response status code may be: 
- 200: for a session successfully reviewed
- 400: invalid input
- 404: for a mentor trying to review a session that doesn't exist
- 404: for  user trying to review a session while he/she is not the mentee for that session
- 403: when a token has not been provided

#### How should this be manually tested?
- Clone this repository to the computer and "run npm start" into your VS CODE EDITOR console. 
- Login and get the token
- use POST http verb, type "x-auth-token" in Header section of POSTMAN and paste the copied token into the "x-auth-token" value section
- Type "localhost:3000/api/v1/sessions/:sessionId/review" and replace (:sessionId) by any number of your choice  and hit SEND button
#### What are the relevant pivotal tracker stories?
review_mentorship_session-168206083
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/53488656/63177604-9286d900-c048-11e9-83b4-efdf14d1c7d0.png)
