### PR TITLE
#168206093 add delete mentorship session endpoint

### DIFF
--- a/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
+++ b/FREE-MENTORS_BACKEND/CONTROLLERS/session_Controler.js
@@ -195,6 +195,36 @@ class sessionControler{
             }
         }
     }
+
+    //Delete a review deemed as inappropriate (By admin only)
+    deleteSessionReview(req, res){
+        const is_admin_check= req.user_token.is_admin;
+        if(is_admin_check===true){
+            const sess_rev_id= parseInt(req.params.sessionId);
+            const session_arr= session_inst.allSessions;
+            const session_exist= session_arr.find(session_chk=>session_chk.sessionId===sess_rev_id);
+            if((session_exist) && (session_exist.score) && (session_exist.score<3)){
+                const found_session_index= session_arr.indexOf(session_exist);
+                session_arr.splice(found_session_index, 1);
+                return res.status(200).json({
+                    status: 200,
+                    data: {
+                        message: "Review successfully deleted"
+                    }
+                });
+            }else{
+                return res.status(404).json({
+                    status: 404,
+                    error: "Denied! Check if session exists and its score<3 "
+                });
+            }
+        }{
+            return res.status(400).json({
+                status: 400,
+                error: "Denied! Only Admininstrator can delete a session review"
+            });
+        }
+    }
 }
 
 const session_contrl= new sessionControler();

--- a/FREE-MENTORS_BACKEND/ROUTES/Routes.js
+++ b/FREE-MENTORS_BACKEND/ROUTES/Routes.js
@@ -18,5 +18,6 @@ router.patch('/api/v1/sessions/:sessionId/accept',verifyToken, session_contrl.ac
 router.patch('/api/v1/sessions/:sessionId/reject',verifyToken, session_contrl.rejectSessionRequest); //Reject session req
 router.get('/api/v1/sessions',verifyToken, session_contrl.getAllSession); //Get all mentorship sessions
 router.post('/api/v1/session/:sessionId/review',verifyToken,session_contrl.reviewSession); //Review a mentorship session
+router.delete('/api/v1/sessions/:sessionId/review',verifyToken,session_contrl.deleteSessionReview); //Delete session review
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
delete mentorship session review endpoint
#### Description of Task to be completed?
delete mentorship session review endpoint takes (user token and sessionId) as request and returns (message: "Review successfully deleted") as response. Also response status code may be: 
- 200: for a session review successfully deleted
- 400: invalid input
- 404: for an admin trying to delete a session that doesn't exist or not reviewed or still pending
- 403: when a token has not been provided
#### How should this be manually tested?
- Clone this repository to the computer and "run npm start" into your VS CODE EDITOR console. 
- Login and get the token
- use DELETE http verb, type "x-auth-token" in Header section of POSTMAN and paste the copied token into the "x-auth-token" value section
- Type "localhost:3000/api/v1/sessions/:sessionId/review" and replace (:sessionId) by any number of your choice  and hit SEND button
#### What are the relevant pivotal tracker stories?
delete_mentorship_session-168206093
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/53488656/63181746-0d53f200-c051-11e9-92b0-c7208f691132.png)
