### PR TITLE
#168206363 add swagger documentation chore

### DIFF
--- a/SWAGGER/swagger.json
+++ b/SWAGGER/swagger.json
@@ -1,0 +1,558 @@
+{
+    "swagger": "2.0",
+    "info": {
+      "version": "1.0.0",
+      "title": "Free Mentors",
+      "description": "Free Mentors is a social initiative where accomplished professionals become role models to young people to provide free mentorship sessions."
+    },
+    "basePath": "/api/v1",
+    "tags": [
+      {
+        "name": "Users",
+        "description": "API Endpoints for user accounts"
+      },
+      {
+        "name": "Sessions",
+        "description": "API Endpoints for mentorship sessions"
+      }
+    ],
+    "schemes": [
+      "https",
+      "http"
+    ],
+    "consumes": [
+      "application/json"
+    ],
+    "produces": [
+      "application/json"
+    ],
+    "paths": {
+      "/auth/signup": {
+        "post": {
+          "tags": [
+            "Users"
+          ],
+          "summary": "Create account for new user",
+          "description": "Create a new  account",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name": "firstName",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            },
+            {
+              "name": "lastName",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            },
+            {
+              "name": "email",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            },
+            {
+              "name": "password",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            },
+            {
+              "name": "address",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            },
+            {
+              "name": "bio",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            },
+            {
+              "name": "occupation",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            },
+            {
+              "name": "expertise",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            }
+          ],
+          "responses": {
+            "201": {
+              "description": "message: User created successfully"
+            },
+            "409": {
+              "description": "message: This account already exists.Try another one."
+            },
+            "400": {
+              "description": "error: Invalid input."
+            }
+          }
+        }
+      },
+
+      "/auth/signin": {
+        "post": {
+          "tags": [
+            "Users"
+          ],
+          "summary": "Login a user",
+          "description": "User Login",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name": "email",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            },
+            {
+              "name": "password",
+              "in": "formData",
+              "required": true,
+              "type": "string",
+              "description": ""
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: User is successfully logged in"
+            },
+            "404": {
+              "description": "error: Account not found. Incorrect Username or Password"
+            },
+            "400": {
+              "description": "error: Invalid input."
+            }
+          }
+        }
+      },
+
+      "/user/{userId}": {
+        "patch": {
+          "tags": [
+            "Users"
+          ],
+          "summary": "Change user role",
+          "description": "Change user to a mentor",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name":"x-auth-token",
+              "in": "header",
+              "description" :"User Token",
+              "required":true
+            },
+            {
+              "name": "userId",
+              "in": "path",
+              "description": "user id for to check admin role",
+              "required": true,
+              "type": "integer"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: User account changed to mentor"
+            },
+            "404": {
+              "description": "error: A mentee with such userId not found"
+            },
+            "400": {
+              "description": "error: Only Administrator can change a user to a mentor"
+            },
+            "403": {
+              "description": "error: Access denied. Token is required"
+            }
+          }
+        }
+      },
+
+
+      "/mentors": {
+        "get": {
+          "tags": [
+            "Users"
+          ],
+          "summary": "Mentors",
+          "description": "View all mentors",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name":"x-auth-token",
+              "in": "header",
+              "description" :"User Token",
+              "required":true
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: Ok! Mentors found"
+            },
+            "404": {
+              "description": "error: No mentors available yet"
+            },
+            "403": {
+              "description": "error: Access denied. Token is required"
+            }
+          }
+        }
+      },
+
+
+      "/mentors/{userId}": {
+        "get": {
+          "tags": [
+            "Users"
+          ],
+          "summary": "View a mentor",
+          "description": "View a specific mentor by Id",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name":"x-auth-token",
+              "in": "header",
+              "description" :"User Token",
+              "required":true
+            },
+            {
+              "name": "userId",
+              "in": "path",
+              "required": true,
+              "type": "integer",
+              "description": ""
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: OK! A mentor found"
+            },
+            "400": {
+              "description": "error: Invalid input."
+            },
+            "404": {
+              "description": "error: user for this Id not found"
+            },
+            "403": {
+              "description": "error: Access denied. Token is required"
+            }
+          }
+        }
+      },
+
+      "/session": {
+        "post": {
+          "tags": [
+            "Sessions"
+          ],
+          "summary": "Session",
+          "description": "Create a mentorship session",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name":"x-auth-token",
+              "in": "header",
+              "description" :"User Token",
+              "required":true
+            },
+            {
+              "name": "mentorId",
+              "in": "formData",
+              "description": "mentorId",
+              "required": true,
+              "type": "integer"
+            },
+            {
+              "name": "questions",
+              "in": "formData",
+              "description": "questions",
+              "required": true,
+              "type": "string"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: Ok! Mentorship session created successfully"
+            },
+            "404": {
+              "description": "error: A user with such Id not found OR A mentor with such Id not found"
+            },
+            "400": {
+              "description": "error: Invalid input"
+            },
+            "403": {
+              "description": "error: Access denied. Token is required"
+            }
+          }
+        }
+      },
+
+      "/sessions/{sessionId}/accept": {
+        "patch": {
+          "tags": [
+            "Sessions"
+          ],
+          "summary": "Session status update",
+          "description": "Mentor accept mentorship session request",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name":"x-auth-token",
+              "in": "header",
+              "description" :"User Token",
+              "required":true
+            },
+            {
+              "name": "sessionId",
+              "in": "path",
+              "description": "Session Id",
+              "required": true,
+              "type": "integer"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: OK! mentorship session accepted"
+            },
+            "404": {
+              "description": "error: Denied! You are not a mentor for this session OR No session with such Id found"
+            },
+            "403": {
+              "description": "error: Access denied. Token is required"
+            }
+          }
+        }
+      },
+
+      "/sessions/{sessionId}/reject": {
+        "patch": {
+          "tags": [
+            "Sessions"
+          ],
+          "summary": "Update session status",
+          "description": "Mentor reject mentorship session request",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name":"x-auth-token",
+              "in": "header",
+              "description" :"User Token",
+              "required":true
+            },
+            {
+              "name": "sessionId",
+              "in": "path",
+              "description": "Session Id",
+              "required": true,
+              "type": "integer"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: OK! mentorship session rejected"
+            },
+            "404": {
+              "description": "error: Denied! You are not a mentor for this session OR No session with such Id found"
+            },
+            "403": {
+              "description": "error: Access denied. Token is required"
+            }
+          }
+        }
+      },
+
+      "/sessions": {
+        "get": {
+          "tags": [
+            "Sessions"
+          ],
+          "summary": "Get Sessions",
+          "description": "View all sessions",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name":"x-auth-token",
+              "in": "header",
+              "description" :"User Token",
+              "required":true
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: OK! Sessions found"
+            },
+            "404": {
+              "description": "error: Mentorship session(s) not found"
+            },
+            "403": {
+              "description": "error: Access denied. Token is required"
+            }
+          }
+        }
+      },
+
+      "/session/{sessionId}/review": {
+        "post": {
+          "tags": [
+            "Sessions"
+          ],
+          "summary": "Session review",
+          "description": "A mentor review finished mentorship session",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name":"x-auth-token",
+              "in": "header",
+              "description" :"User Token",
+              "required":true
+            },
+            {
+              "name": "sessionId",
+              "in": "path",
+              "description": "Session Id",
+              "required":true,
+              "type":"integer"
+            },
+            {
+              "name": "score",
+              "in": "formData",
+              "description": "Review score",
+              "required":true,
+              "type":"integer"
+            },
+            {
+              "name": "remark",
+              "in": "formData",
+              "description": "Review remark",
+              "required":true,
+              "type":"string"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: OK! Mentorship review submitted successfully"
+            },
+            "404": {
+              "description": "error: You are not allowed to review this session OR mentorship session not found"
+            },
+            "403": {
+              "description": "error: Access denied. Token is required"
+            }
+          }
+        }
+      },
+
+      "/sessions/{sessionId}/review": {
+        "delete": {
+          "tags": [
+            "Sessions"
+          ],
+          "summary": "Session review",
+          "description": "Admin delete session review deemed as inappropriate",
+          "produces": [
+            "application/json"
+          ],
+          "consumes": [
+            "application/x-www-form-urlencoded"
+          ],
+          "parameters": [
+            {
+              "name":"x-auth-token",
+              "in": "header",
+              "description" :"User Token",
+              "required":true
+            },
+            {
+              "name": "sessionId",
+              "in": "path",
+              "description": "Session Id",
+              "required":true,
+              "type":"integer"
+            }
+          ],
+          "responses": {
+            "200": {
+              "description": "message: Review successfully deleted"
+            },
+            "400": {
+              "description": "error: Denied! Only Admininstrator can delete a session review"
+            },
+            "404": {
+              "description": "error: Denied! Check if session exists and its score<3"
+            },
+            "403": {
+              "description": "error: Access denied. Token is required"
+            }
+          }
+        }
+      }
+    }
+  }
+  

--- a/server.js
+++ b/server.js
@@ -1,10 +1,14 @@
 import express from 'express';
 import body_parser from 'body-parser';
 import router from './ROUTES/Routes';
+import swaggerUi from 'swagger-ui-express';
+import swaggerDoc from './SWAGGER/swagger.json';
 
 const app= express();
 app.use(body_parser.json());
 app.use(body_parser.urlencoded({extended : false}));
+
+app.use('/freementors', swaggerUi.serve, swaggerUi.setup(swaggerDoc));
 
 app.get('/',(req,res)=>{
     return res.status(200).json({


### PR DESCRIPTION
#### What does this PR do?
add swagger documentation for all endpoints
#### Description of Task to be completed?
This Pull request adds add swagger documentation for all endpoints in the Free mentors project The documentation is made by using swagger-ui-express and swagger-jsdoc node modules.
#### How should this be manually tested?
- Free mentors swagger documentation link: https://adc-10.herokuapp.com/freementors/
#### What are the relevant pivotal tracker stories?
swagger_documentation-168206363
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/53488656/63230522-fd354180-c20d-11e9-989d-c72f60290f81.png)
![image](https://user-images.githubusercontent.com/53488656/63230526-12aa6b80-c20e-11e9-8376-f9c13a01c0ad.png)
![image](https://user-images.githubusercontent.com/53488656/63230533-2c4bb300-c20e-11e9-817d-9b7061a77663.png)
![image](https://user-images.githubusercontent.com/53488656/63230540-3a013880-c20e-11e9-86df-1ff49ec83c76.png)


